### PR TITLE
modify adding Kubernetes repo using curl for Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Hello,
   
 Welcome to Vietnam Kubernetes Community.
 
+Founded by the former OpenStack Team at Fujitsu, we hope to bridge the gap of knowledge in the open-source community and lay a new foundation for Kubernetes users in Vietnam in the near future.
+
 https://vietkubers.github.io/
 
 Copyright © 2018, [VietKubers](https://github.com/vietkubers). Released under the [MIT License](https://github.com/vietkubers/vietkubers.github.io/blob/master/LICENSE).

--- a/_posts/2018-11-21-deploying-multiplenodes-with-kubeadm.md
+++ b/_posts/2018-11-21-deploying-multiplenodes-with-kubeadm.md
@@ -54,6 +54,7 @@ Environment="HTTP_PROXY=http://[Proxy_Server]:[Proxy_Port]/"
 
 Adding kubernetes repo:
 ```
+$ curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 $ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >> ~/kubernetes.list
 $ sudo mv ~/kubernetes.list /etc/apt/sources.list.d
 $ sudo apt-get update

--- a/about.md
+++ b/about.md
@@ -10,4 +10,6 @@ Welcome to **Vietnam Kubernetes Community**
 
 https://vietkubers.github.io/
 
+Kubernetes has been an evolving technology for deploying containerized applications. Powered by Google, Kubernetes is capable of running billions of containers per week, allowing you to scale your application without increasing your ops team. And yet, we have not had an organized community in Vietnam to gather and discuss this budding technology. VietKubers was founded on the basis of learning and sharing our knowledge together in a thriving environment. Founded by the former OpenStack Team at Fujitsu, we hope to bridge the gap of knowledge in the open-source community and lay a new foundation for Kubernetes users in Vietnam in the near future.
+
 Copyright © 2018, [VietKubers](https://github.com/vietkubers). Released under the [MIT License](https://github.com/vietkubers/vietkubers.github.io/blob/master/LICENSE).


### PR DESCRIPTION
As the current guide for installing kubeadm on a two-node model generated some errors for Ubuntu 18.04, I fixed it a little using the guide on https://kubernetes.io/docs/setup/independent/install-kubeadm/